### PR TITLE
Catch exception when data attribute was not present on column

### DIFF
--- a/eddytools/schema.py
+++ b/eddytools/schema.py
@@ -64,7 +64,8 @@ def filter_binary_columns(metadata: MetaData):
     for c in metadata.tables.values():
         cols_to_remove = [col for col in c.columns if isinstance(col.type, (_Binary, CLOB, BLOB, Text, NullType))]
         for col in cols_to_remove:
-            c.columns._data.pop(col.name)
+            if hasattr(c.columns, '_data'):
+                c.columns._data.pop(col.name)
 
 
 def retrieve_classes(metadata) -> list:


### PR DESCRIPTION
During schema extraction I encountered an `AttributeError` thrown in schema.py. I honestly didn't do any digging around to see whether there was some underlying cause that I might miss, but this fix got rid of the error and the results seemed to be sane.